### PR TITLE
Rename trie to tree in design

### DIFF
--- a/tree.md
+++ b/tree.md
@@ -1,9 +1,9 @@
 # Tree Specification
-This document specifies the structure of the wasmchain Trie.
-The Trie has features of [PPSP](https://tools.ietf.org/html/rfc7574#section-5.1) and [Merkle Mountain Ranges](https://github.com/mimblewimble/grin/blob/master/doc/mmr.md). The Trie differs from Ethereum's trie in that it does not store key/value entries. Instead, it only stores data at given integer indices.
+This document specifies the structure of the wasmchain Tree.
+The Tree has features of [PPSP](https://tools.ietf.org/html/rfc7574#section-5.1) and [Merkle Mountain Ranges](https://github.com/mimblewimble/grin/blob/master/doc/mmr.md). The Tree differs from Ethereum's tree in that it does not store key/value entries. Instead, it only stores data at given integer indices.
 
-## The Trie Structure
-The Trie is a binary trie where all leaf nodes have a uniform depth. For example:
+## The Tree Structure
+The Tree is a binary tree where all leaf nodes have a uniform depth. For example:
 ```
                                   7
                                  / \
@@ -19,12 +19,12 @@ The Trie is a binary trie where all leaf nodes have a uniform depth. For example
                    0   2   4   6    8   10  12   14
 
 ```
-Addresses are generated serially, and hence the Trie indices represent the order of address creation. </br>
+Addresses are generated serially, and hence the Tree indices represent the order of address creation. </br>
 As a result of this property, all nodes with an even index are LEAF nodes. </br>
 Another benefit of sequential address generation is its inherent amenability to serialization in an append-only flat file format. </br> 
 The numbers represent the order in which all the nodes where created, and the even nodes are the leaf nodes.
 
-## Trie Nodes
+## Tree Nodes
 There are three types of nodes: ROOT, BRANCH, and LEAF. 
 
 ```
@@ -34,13 +34,13 @@ NODE := ROOT
 ```
 
 ### ROOT
-A Trie has at most one ROOT node. The root node contains two elements: an "EDGE" and METADATA.
+A Tree has at most one ROOT node. The root node contains two elements: an "EDGE" and METADATA.
 
 ```
 ROOT := (EDGE, METADATA)
 ```
 
-For now, "METADATA" just contains a single element, the trie's "HEIGHT" which is encoded as an LEB128 unsigned integer.
+For now, "METADATA" just contains a single element, the tree's "HEIGHT" which is encoded as an LEB128 unsigned integer.
 
 ### BRANCH
 Each branch node contains two "EDGE" elements: "left EDGE", "right EDGE".

--- a/tree.md
+++ b/tree.md
@@ -1,5 +1,6 @@
 # Tree Specification
-This document specifies the structure of the wasmchain Tree.
+This document specifies the structure of the tree in Wortels.
+
 The Tree has features of [PPSP](https://tools.ietf.org/html/rfc7574#section-5.1) and [Merkle Mountain Ranges](https://github.com/mimblewimble/grin/blob/master/doc/mmr.md). The Tree differs from Ethereum's tree in that it does not store key/value entries. Instead, it only stores data at given integer indices.
 
 ## The Tree Structure


### PR DESCRIPTION
Because a trie is apparently a prefix tree, only.